### PR TITLE
Added missing translation

### DIFF
--- a/Inputs/Translations_EN.yml
+++ b/Inputs/Translations_EN.yml
@@ -1692,7 +1692,7 @@
   desc : Tip box - Part 1
   ##############################
   find : <BD C3 C0 DB C7 D2 20 B6 A7 20 BF AD B1 E2>
-  replace : "Save Tip?"
+  replace : "Open on start"
   startDate : 20171018
 
 -
@@ -1700,7 +1700,7 @@
   desc : Tip box - Part 2
   ##############################
   find : <B4 DD B1 E2>
-  replace : "Done"
+  replace : "Exit"
 
 -
   ##############################
@@ -1721,3 +1721,11 @@
   replace : "%d"
   startDate : 20171208
   endDate : 20191105
+
+-
+  #################################
+  desc : Equipment - Dismount Cart
+  #################################
+  find : <C4 AB C6 AE 20 C7 D8 C1 A6>
+  replace : "Dismount Cart"
+  startDateRE : 20210107


### PR DESCRIPTION
* Adds the "Dismount Cart" translation to the drop down menu on the equipment window in case a Mechanic has both, a cart and mado gear equipped and you're trying to take the cart off.
**Note:** I'm not sure about the startDateRE, but 20210107 was the first time i've seen it.

* Fixed bad Tip Box translations.