### PR TITLE
Fix missing LANGTYPE for clients above 2023-06-07_Ragexe_1686120134 up to 2024-07-17_Ragexe_1720748271

### DIFF
--- a/Scripts/Init/LangType.mjs
+++ b/Scripts/Init/LangType.mjs
@@ -1,6 +1,7 @@
 /**************************************************************************\
 *                                                                          *
 *   Copyright (C) 2021 Neo-Mind                                            *
+*   Copyright (C) 2023-2024 X-EcutiOnner (xex.ecutionner@gmail.com)        *
 *                                                                          *
 *   This file is a part of WARP project                                    *
 *                                                                          *
@@ -20,15 +21,15 @@
 *                                                                          *
 |**************************************************************************|
 *                                                                          *
-*   Author(s)     : Neo-Mind                                               *
+*   Author(s)     : Neo-Mind, X-EcutiOnner                                 *
 *   Created Date  : 2021-08-20                                             *
-*   Last Modified : 2021-08-20                                             *
+*   Last Modified : 2024-01-24                                             *
 *                                                                          *
 \**************************************************************************/
 
 //
 // Stores the language type
-// ========================
+// =========================
 //
 // MODULE_NAME => LANGTYPE
 // -----------------------
@@ -48,12 +49,12 @@ var Hex;    //It's hex in Little Endian form
 ///
 export function init()
 {
-	Value   = -1;
-	Hex     = '';
-	Valid  = null;
-	ErrMsg = null;
+    Value  = -1;
+    Hex    = '';
+    Valid  = null;
+    ErrMsg = null;
 
-	Identify(self, ['init', 'load', 'toString', 'valueOf']);
+    Identify(self, ['init', 'load', 'toString', 'valueOf']);
 }
 
 ///
@@ -61,44 +62,45 @@ export function init()
 ///
 export function load()
 {
-	const _ = Log.dive(self, 'load');
+    const _ = Log.dive(self, 'load');
 
-	$$(_ + '1.1 - Check if load was already called')
-	if (Valid != null)
-	{
-		$$(_ + '1.2 - Check for errors and report them again if present otherwise simply return')
-		Log.rise();
+    $$(_ + '1.1 - Check if load was already called')
+    if (Valid != null)
+    {
+        $$(_ + '1.2 - Check for errors and report them again if present otherwise simply return')
+        Log.rise();
 
-		if (Valid)
-			return Valid;
-		else
-			throw ErrMsg;
-	}
+        if (Valid)
+            return Valid;
+        else
+            throw ErrMsg;
+    }
 
-	$$(_ + '1.3 - Initialize \'Valid\' to false')
-	Valid = false;
+    $$(_ + '1.3 - Initialize \'Valid\' to false')
+    Valid = false;
 
-	$$(_ + '1.4 - Find the string "america"')
-	let addr = Exe.FindText("america");
-	if (addr < 0)
-		throw Log.rise(ErrMsg = new Error(`${self} - 'america' not found`));
+    $$(_ + '1.4 - Find the string "servicetype"')
+    const StrReg = Exe.BuildDate <= 20230607 ? "america" : "servicetype";
+    let addr = Exe.FindText(StrReg);
+    if (addr < 0)
+        throw Log.rise(ErrMsg = new Error(`${self} - 'g_serviceType' not found`));
 
-	$$(_ + '1.5 - Find where its used in a PUSH')
-	addr = Exe.FindHex( PUSH(addr) );
-	if (addr < 0)
-		throw Log.rise(ErrMsg = new Error(`${self} - 'america' not used`));
+    $$(_ + '1.5 - Find where its used in a PUSH')
+    addr = Exe.FindHex(PUSH(addr));
+    if (addr < 0)
+        throw Log.rise(ErrMsg = new Error(`${self} - 'g_serviceType' not used`));
 
-	$$(_ + '1.6 - Find an assignment to g_serviceType after it')
-	addr = Exe.FindHex( MOV([POS4WC], 1), addr + 5); //mov dword ptr ds:[g_serviceType], 1
-	if (addr < 0)
-		throw Log.rise(ErrMsg = new Error(`${self} - g_serviceType not assigned`));
+    $$(_ + '1.6 - Find an assignment to g_serviceType after it')
+    addr = Exe.FindHex(MOV([POS4WC], 1), addr + 5); //mov dword ptr ds:[g_serviceType], 1
+    if (addr < 0)
+        throw Log.rise(ErrMsg = new Error(`${self} - g_serviceType not assigned`));
 
-	$$(_ + '2.1 - Extract the address to \'Value\' & save its hex')
-	Value = Exe.GetUint32(addr + 2);
-	Hex = Value.toHex(4);
+    $$(_ + '2.1 - Extract the address to \'Value\' & save its hex')
+    Value = Exe.GetUint32(addr + 2);
+    Hex = Value.toHex(4);
 
-	$$(_ + '2.2 - Set validity to true')
-	return Log.rise(Valid = true);
+    $$(_ + '2.2 - Set validity to true')
+    return Log.rise(Valid = true);
 }
 
 ///
@@ -106,7 +108,7 @@ export function load()
 ///
 export function toString()
 {
-	return Hex;
+    return Hex;
 }
 
 ///
@@ -114,5 +116,5 @@ export function toString()
 ///
 export function valueOf()
 {
-	return Value;
+    return Value;
 }


### PR DESCRIPTION
LANGTYPE will be used in the patches below #132
- Always call SelectKoreaClientInfo() #133
- Allow unlimited chat repeat
- Customize chat repeat limit
- Customize chat color (GM)
- Customize chat color (Guild)
- Customize chat color (Party - Others)
- Customize chat color (Party - Self)
- Customize chat color (Public - Others)
- Customize chat color (Public - Self)
- Enable Custom Homunculus
- Enable Custom Jobs
- Always use email for Char Deletion
- Disable Login password encryption
- Disable Map packet encryption
- Disable Login/Char packet encryption
- Disable Login password encryption
- Enable Official custom .eot Fonts
- Enable flag emoticons
- Enable Mail Box access for All Langtypes
- Always enable '/who' command
- Always enable '/showname' command
- Allow unknown '/command's [Experimental]
- Translate arrows to English
- Fix charset for Fonts
- Always hide License Screen
- Always show License Screen
- Always load korea ExternalSettings lua file
- Restore Login Window
- Use SSO Login Packet
- Use Old Login Packet
- No Help Message on Login
- Use official cloth palettes
- Use plain text descriptions
- Always read msgstringtable.txt
- Always read questid2display.txt
- Send client flags
- Send MD5 hash packet
- Always show Replay button in Service Select
- Always show Cancel button in Login
- Always show Register button in Login
