### PR TITLE
Removed CLS (Custom Lua Support) for navigation

### DIFF
--- a/Inputs/LuaOvrdSpec.yml
+++ b/Inputs/LuaOvrdSpec.yml
@@ -22,7 +22,7 @@
 #                                                                          #
 #   Author(s)     : Neo-Mind                                               #
 #   Created Date  : 2022-09-29                                             #
-#   Last Modified : 2024-08-31                                             #
+#   Last Modified : 2025-01-09                                             #
 #                                                                          #
 ############################################################################
 
@@ -61,16 +61,6 @@ LoadAfter:
     DataInfo\NPCIdentity: cls\npcidentity
     DataInfo\PetInfo: cls\petinfo
     DataInfo\ShadowTable: cls\shadowtable
-    
-    # Navigation overrides (Sak & pri suffixes for the keys are automatically added in code)
-    Navigation\Navi_Map_kr: cls\navi_map
-    Navigation\Navi_Npc_kr: cls\navi_npc
-    Navigation\Navi_Mob_kr: cls\navi_mob
-    Navigation\Navi_Link_kr: cls\navi_link
-    Navigation\Navi_LinkDistance_kr: cls\navi_linkdistance
-    Navigation\Navi_NpcDistance_kr: cls\navi_npcdistance
-    Navigation\navi_picknpc_kr: cls\navi_picknpc
-    Navigation\Navi_Scroll_kr: cls\navi_scroll
     
     # Random option overrides
     DataInfo\EnumVAR: cls\enumvar


### PR DESCRIPTION
rAthena users have access to the map-server-generator (VS), which builds navi-generator.bat to create navigation files based on the server content.
Not sure about Hercules anymore.
Therefore there is no need for those files in my opinion.