### PR TITLE
spopup and QuestQualificationInfo Patches (WIP)

### DIFF
--- a/Patches/Data.yml
+++ b/Patches/Data.yml
@@ -340,6 +340,72 @@ CustomPath:
             author : Jian
             desc : Make the client load user specified lua file instead of <b>RecommendedQuestInfoList*.lub</b>.
 
+        - CustomspopupLub:
+            title : Customize spopup lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>spopup.lub</b>.
+
+        - CustomChangeMatLub:
+            title : Customize ChangeMaterial lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>ChangeMaterial.lub</b>.
+
+        - CustomQuestQualiLub:
+            title : Customize QuestClassificationInfo lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>QuestClassificationInfo.lub</b>.
+        
+        - CustomRuneDescLub:
+            title : Customize Rune\rune_desc lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>rune_desc.lub</b>.
+
+        - CustomRuneSetDescLub:
+            title : Customize Rune\runeset_desc lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>runeset_desc.lub</b>.
+
+        - CustomitemDecomLub:
+            title : Customize Rune\itemDecom lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>itemDecom.lub</b>.
+
+        - CustomRuneInfoLub:
+            title : Customize Rune\rune_info lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>rune_info.lub</b>.
+
+        - CustomRuneSetInfoLub:
+            title : Customize Rune\runeset_info lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>runeset_info.lub</b>.
+
+        - CustomRuneSystemTableLub:
+            title : Customize Rune\runeSystem_table lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>runeSystem_table.lub</b>.
+
+        - CustomRuneSystemIdLub:
+            title : Customize Rune\runesystemid lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>runesystemid.lub</b>.
+
+        - CustomRuneSystemInfoLub:
+            title : Customize Rune\runesystemInfo lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of Rune\<b>runesystemInfo.lub</b>.
+
         - CustomLicenseTxt:
             title : Customize License File
             recommend : no

--- a/Patches/Data.yml
+++ b/Patches/Data.yml
@@ -338,13 +338,25 @@ CustomPath:
             title : Customize RecommendedQuestInfoList lub
             recommend : no
             author : Jian
-            desc : Make the client load user specified lua file instead of <b>RecommendedQuestInfoList*.lub</b>.     
+            desc : Make the client load user specified lua file instead of <b>RecommendedQuestInfoList*.lub</b>.
+
+        - CustomspopupLub:
+            title : Customize spopup lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>spopup.lub</b>.
 
         - CustomChangeMatLub:
             title : Customize ChangeMaterial lub
             recommend : no
             author : llchrisll
             desc : Make the client load user specified lua file instead of <b>ChangeMaterial.lub</b>.
+
+        - CustomQuestQualiLub:
+            title : Customize QuestClassificationInfo lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>QuestClassificationInfo.lub</b>.
         
         - CustomRuneDescLub:
             title : Customize Rune\rune_desc lub

--- a/Patches/Data.yml
+++ b/Patches/Data.yml
@@ -338,25 +338,13 @@ CustomPath:
             title : Customize RecommendedQuestInfoList lub
             recommend : no
             author : Jian
-            desc : Make the client load user specified lua file instead of <b>RecommendedQuestInfoList*.lub</b>.
-
-        - CustomspopupLub:
-            title : Customize spopup lub
-            recommend : no
-            author : llchrisll
-            desc : Make the client load user specified lua file instead of <b>spopup.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>RecommendedQuestInfoList*.lub</b>.     
 
         - CustomChangeMatLub:
             title : Customize ChangeMaterial lub
             recommend : no
             author : llchrisll
             desc : Make the client load user specified lua file instead of <b>ChangeMaterial.lub</b>.
-
-        - CustomQuestQualiLub:
-            title : Customize QuestClassificationInfo lub
-            recommend : no
-            author : llchrisll
-            desc : Make the client load user specified lua file instead of <b>QuestClassificationInfo.lub</b>.
         
         - CustomRuneDescLub:
             title : Customize Rune\rune_desc lub

--- a/Patches/Data.yml
+++ b/Patches/Data.yml
@@ -362,49 +362,55 @@ CustomPath:
             title : Customize Rune\rune_desc lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>rune_desc.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\rune_desc.lub</b>.
 
         - CustomRuneSetDescLub:
             title : Customize Rune\runeset_desc lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>runeset_desc.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\runeset_desc.lub</b>.
 
         - CustomitemDecomLub:
             title : Customize Rune\itemDecom lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>itemDecom.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\itemDecom.lub</b>.
 
         - CustomRuneInfoLub:
             title : Customize Rune\rune_info lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>rune_info.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\rune_info.lub</b>.
 
         - CustomRuneSetInfoLub:
             title : Customize Rune\runeset_info lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>runeset_info.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\runeset_info.lub</b>.
 
         - CustomRuneSystemTableLub:
             title : Customize Rune\runeSystem_table lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>runeSystem_table.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\runeSystem_table.lub</b>.
 
         - CustomRuneSystemIdLub:
             title : Customize Rune\runesystemid lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>runesystemid.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\runesystemid.lub</b>.
 
         - CustomRuneSystemInfoLub:
             title : Customize Rune\runesystemInfo lub
             recommend : no
             author : llchrisll
-            desc : Make the client load user specified lua file instead of Rune\<b>runesystemInfo.lub</b>.
+            desc : Make the client load user specified lua file instead of <b>Rune\runesystemInfo.lub</b>.
+
+        - CustomRuneRewardLub:
+            title : Customize Rune\runeset_reward lub
+            recommend : no
+            author : llchrisll
+            desc : Make the client load user specified lua file instead of <b>Rune\runeset_reward.lub</b>.
 
         - CustomLicenseTxt:
             title : Customize License File

--- a/Scripts/Patches/CustomPath.qjs
+++ b/Scripts/Patches/CustomPath.qjs
@@ -137,6 +137,17 @@ CustomMapInfoLub       = CustomPath;
 CustomOngQuestInfoLub  = CustomPath;
 CustomRcmdQuestInfoLub = CustomPath;
 CustomMonSizeEffLub    = CustomPath;
+CustomspopupLub        = CustomPath;
+CustomChangeMatLub     = CustomPath;
+CustomQuestQualiLub    = CustomPath;
+CustomRuneDescLub      = CustomPath;
+CustomRuneSetDescLub   = CustomPath;
+CustomitemDecomLub     = CustomPath;
+CustomRuneInfoLub      = CustomPath;
+CustomRuneSetInfoLub   = CustomPath;
+CustomRuneSystemTableLub = CustomPath;
+CustomRuneSystemIdLub  = CustomPath;
+CustomRuneSystemInfoLub = CustomPath;
 
 ///
 /// \brief Data to be used for the above patches
@@ -236,6 +247,94 @@ CustomPath.Data = MakeMap(
 		varName : '$newRcmdQInfoList',
 		prefix : "Recommended QuestInfoList Lua",
 		parts : ["system\\RecommendedQuestInfoList", "_Sakray", "_True"]
+	},
+	
+	'CustomspopupLub',
+	{
+		strType : "Path",
+		varName : '$newspopup',
+		prefix : "spopup Lua",
+		knownName : "System\\spopup.lub"
+	},
+	
+	'CustomChangeMatLub',
+	{
+		strType : "Path",
+		varName : '$newspopup',
+		prefix : "spopup Lua",
+		knownName : "System\\ChangeMaterial.lub"
+	},
+	
+	'CustomQuestQualiLub',
+	{
+		strType : "Path",
+		varName : '$newQuestQuali',
+		prefix : "QuestClassificationInfo Lua",
+		knownName : "System\\QuestClassificationInfo.lub"
+	},
+	
+	'CustomRuneDescLub',
+	{
+		strType : "Path",
+		varName : '$newRuneDesc',
+		prefix : "Rune\rune_desc Lua",
+		knownName : "System\\Rune\\rune_desc.lub"
+	},
+	
+	'CustomRuneSetDescLub',
+	{
+		strType : "Path",
+		varName : '$newRuneSetDesc',
+		prefix : "Rune\runeset_desc Lua",
+		knownName : "System\\Rune\\runeset_desc.lub"
+	},
+	
+	'CustomitemDecomLub',
+	{
+		strType : "Path",
+		varName : '$newitemDecom',
+		prefix : "Rune\itemDecom Lua",
+		knownName : "System\\Rune\\itemDecom.lub"
+	},
+	
+	'CustomRuneInfoLub',
+	{
+		strType : "Path",
+		varName : '$newruneinfo',
+		prefix : "Rune\rune_info Lua",
+		knownName : "System\\Rune\\rune_info.lub"
+	},
+	
+	'CustomRuneSetInfoLub',
+	{
+		strType : "Path",
+		varName : '$newrunesetinfo',
+		prefix : "Rune\runeset_info Lua",
+		knownName : "System\\Rune\\runeset_info.lub"
+	},
+	
+	'CustomRuneSystemTableLub',
+	{
+		strType : "Path",
+		varName : '$newruneSystable',
+		prefix : "Rune\runeSystem_table Lua",
+		knownName : "System\\Rune\\runeSystem_table.lub"
+	},
+	
+	'CustomRuneSystemIdLub',
+	{
+		strType : "Path",
+		varName : '$newrunesysid',
+		prefix : "Rune\runesystemid Lua",
+		knownName : "System\\Rune\\runesystemid.lub"
+	},
+	
+	'CustomRuneSystemInfoLub',
+	{
+		strType : "Path",
+		varName : '$newrunesysInfo',
+		prefix : "Rune\runesystemInfo Lua",
+		knownName : "System\\Rune\\runesystemInfo.lub"
 	},
 );
 

--- a/Scripts/Patches/CustomPath.qjs
+++ b/Scripts/Patches/CustomPath.qjs
@@ -45,7 +45,7 @@ CustomPath = function(_)
 	$$(_, 1.3, `Find location where the string is PUSHed`)
 	const addr = Exe.FindHex( PUSH(nameAddr) );
 	if (addr < 0)
-		throw Error(`'${name} not used`);
+		throw Error(`'${name}' not used`);
 
 	$$(_, 1.4, `Get the new file name from user`)
 	const suf = strType === "Prefix" ? "without .lub" : "";
@@ -148,6 +148,7 @@ CustomRuneSetInfoLub   = CustomPath;
 CustomRuneSystemTableLub = CustomPath;
 CustomRuneSystemIdLub  = CustomPath;
 CustomRuneSystemInfoLub = CustomPath;
+CustomRuneRewardLub = CustomPath;
 
 ///
 /// \brief Data to be used for the above patches
@@ -260,9 +261,9 @@ CustomPath.Data = MakeMap(
 	'CustomChangeMatLub',
 	{
 		strType : "Path",
-		varName : '$newspopup',
-		prefix : "spopup Lua",
-		knownName : "System\\ChangeMaterial.lub"
+		varName : '$newchangemat',
+		prefix : "ChangeMaterial Lua",
+		knownName : "System/ChangeMaterial.lub"
 	},
 	
 	'CustomQuestQualiLub',
@@ -277,7 +278,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newRuneDesc',
-		prefix : "Rune\rune_desc Lua",
+		prefix : "rune_desc Lua",
 		knownName : "System\\Rune\\rune_desc.lub"
 	},
 	
@@ -285,7 +286,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newRuneSetDesc',
-		prefix : "Rune\runeset_desc Lua",
+		prefix : "runeset_desc Lua",
 		knownName : "System\\Rune\\runeset_desc.lub"
 	},
 	
@@ -293,7 +294,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newitemDecom',
-		prefix : "Rune\itemDecom Lua",
+		prefix : "itemDecom Lua",
 		knownName : "System\\Rune\\itemDecom.lub"
 	},
 	
@@ -301,7 +302,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newruneinfo',
-		prefix : "Rune\rune_info Lua",
+		prefix : "rune_info Lua",
 		knownName : "System\\Rune\\rune_info.lub"
 	},
 	
@@ -309,7 +310,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newrunesetinfo',
-		prefix : "Rune\runeset_info Lua",
+		prefix : "runeset_info Lua",
 		knownName : "System\\Rune\\runeset_info.lub"
 	},
 	
@@ -317,7 +318,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newruneSystable',
-		prefix : "Rune\runeSystem_table Lua",
+		prefix : "runeSystem_table Lua",
 		knownName : "System\\Rune\\runeSystem_table.lub"
 	},
 	
@@ -325,7 +326,7 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newrunesysid',
-		prefix : "Rune\runesystemid Lua",
+		prefix : "runesystemid Lua",
 		knownName : "System\\Rune\\runesystemid.lub"
 	},
 	
@@ -333,8 +334,15 @@ CustomPath.Data = MakeMap(
 	{
 		strType : "Path",
 		varName : '$newrunesysInfo',
-		prefix : "Rune\runesystemInfo Lua",
+		prefix : "runesystemInfo Lua",
 		knownName : "System\\Rune\\runesystemInfo.lub"
+	},
+	'CustomRuneRewardLub',
+	{
+		strType : "Path",
+		varName : '$newrunerewInfo',
+		prefix : "runeset_reward Lua",
+		knownName : "System\\Rune\\runeset_reward.lub"
 	},
 );
 

--- a/Scripts/Patches/CustomPath.qjs
+++ b/Scripts/Patches/CustomPath.qjs
@@ -137,9 +137,7 @@ CustomMapInfoLub       = CustomPath;
 CustomOngQuestInfoLub  = CustomPath;
 CustomRcmdQuestInfoLub = CustomPath;
 CustomMonSizeEffLub    = CustomPath;
-CustomspopupLub        = CustomPath;
 CustomChangeMatLub     = CustomPath;
-CustomQuestQualiLub    = CustomPath;
 CustomRuneDescLub      = CustomPath;
 CustomRuneSetDescLub   = CustomPath;
 CustomitemDecomLub     = CustomPath;
@@ -250,28 +248,12 @@ CustomPath.Data = MakeMap(
 		parts : ["system\\RecommendedQuestInfoList", "_Sakray", "_True"]
 	},
 	
-	'CustomspopupLub',
-	{
-		strType : "Path",
-		varName : '$newspopup',
-		prefix : "spopup Lua",
-		knownName : "System\\spopup.lub"
-	},
-	
 	'CustomChangeMatLub',
 	{
 		strType : "Path",
 		varName : '$newchangemat',
 		prefix : "ChangeMaterial Lua",
 		knownName : "System/ChangeMaterial.lub"
-	},
-	
-	'CustomQuestQualiLub',
-	{
-		strType : "Path",
-		varName : '$newQuestQuali',
-		prefix : "QuestClassificationInfo Lua",
-		knownName : "System\\QuestClassificationInfo.lub"
 	},
 	
 	'CustomRuneDescLub',

--- a/Scripts/Patches/CustomPath.qjs
+++ b/Scripts/Patches/CustomPath.qjs
@@ -137,7 +137,9 @@ CustomMapInfoLub       = CustomPath;
 CustomOngQuestInfoLub  = CustomPath;
 CustomRcmdQuestInfoLub = CustomPath;
 CustomMonSizeEffLub    = CustomPath;
+CustomspopupLub        = CustomPath;
 CustomChangeMatLub     = CustomPath;
+CustomQuestQualiLub    = CustomPath;
 CustomRuneDescLub      = CustomPath;
 CustomRuneSetDescLub   = CustomPath;
 CustomitemDecomLub     = CustomPath;
@@ -248,12 +250,28 @@ CustomPath.Data = MakeMap(
 		parts : ["system\\RecommendedQuestInfoList", "_Sakray", "_True"]
 	},
 	
+	'CustomspopupLub',
+	{
+		strType : "Path",
+		varName : '$newspopup',
+		prefix : "spopup Lua",
+		knownName : "System\\spopup.lub"
+	},
+	
 	'CustomChangeMatLub',
 	{
 		strType : "Path",
 		varName : '$newchangemat',
 		prefix : "ChangeMaterial Lua",
 		knownName : "System/ChangeMaterial.lub"
+	},
+	
+	'CustomQuestQualiLub',
+	{
+		strType : "Path",
+		varName : '$newQuestQuali',
+		prefix : "QuestClassificationInfo Lua",
+		knownName : "System\\QuestClassificationInfo.lub"
 	},
 	
 	'CustomRuneDescLub',


### PR DESCRIPTION
These two patches are still not working, so I split them from #180 until they are.

In case someone else is able to help me with this, feel free to pm me about it.
Tho we still have to wait for Neo to come back.

Dev Note:  
These two patches require knowledge in RE (Reverse Enginering) to look up the MOV (or whatever) part, as far as I understand.

Quote from Neo back then:
> The path was definitely found in the client. The not used part means the code didn't find it in a PUSH instruction.
> The latest client has used mov instructions for some paths so that makes sense.